### PR TITLE
use kube_pod_labels to select query targets

### DIFF
--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -39,10 +39,9 @@ local userPods = graphPanel.new(
   prometheus.target(
     |||
       sum(
-        # Running pods
-        # FIXME: This is just all pods that have an entry, maybe filter with phase=Running?
-        kube_pod_info{pod=~"^jupyter-.*"}
-      ) by (namespace) > 0
+        kube_pod_status_phase{phase="Running"}
+        * on(pod, namespace) kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server"}
+      ) by (namespace)
     |||,
     legendFormat='{{namespace}}'
   )


### PR DESCRIPTION
should be more reliable than pod name patterns, which don't work for my deployment which happens to be called `hub`.

expands most queries to multi-line since they are getting long with these joins. I don't know how expensive these joins might be for lots of pods, or if there's a better order to express them in.

using these queries, add one panel for all hub components cpu/memory usage by component name, replacing the userScheduler panel which wasn't on the page. It seems like hub, proxy, everything else makes sense to me, rather than needing a panel for every component.