### PR TITLE
set explicit min=0, units

### DIFF
--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -22,6 +22,8 @@ local templates = [
 // Cluster-wide stats
 local userNodes = graphPanel.new(
   'Node Count',
+  decimals=0,
+  min=0,
 ).addTarget(
   prometheus.target(
     expr='sum(kube_node_labels) by (label_cloud_google_com_gke_nodepool)',
@@ -34,7 +36,9 @@ local userPods = graphPanel.new(
   description=|||
     Count of running users, grouped by namespace
   |||,
-  stack=true
+  decimals=0,
+  min=0,
+  stack=true,
 ).addTargets([
   prometheus.target(
     |||
@@ -125,12 +129,13 @@ local clusterCPUCommitment = graphPanel.new(
 
 
 local nodeCPUCommit = graphPanel.new(
-  'CPU commit %',
+  'Node CPU Commit %',
   formatY1='percentunit',
   description=|||
     % of each node guaranteed to pods on it
   |||,
   min=0,
+  max=1,
 ).addTargets([
   prometheus.target(
     |||
@@ -154,12 +159,13 @@ local nodeCPUCommit = graphPanel.new(
 ]);
 
 local nodeMemoryCommit = graphPanel.new(
-  'Memory commit %',
+  'Node Memory Commit %',
   formatY1='percentunit',
   description=|||
     % of each node guaranteed to pods on it
   |||,
   min=0,
+  max=1,
 ).addTargets([
   prometheus.target(
     |||
@@ -190,7 +196,7 @@ local nodeMemoryUtil = graphPanel.new(
     % of available Memory currently in use
   |||,
   min=0,
-  max=1
+  max=1,
 ).addTargets([
   prometheus.target(
     |||
@@ -205,7 +211,7 @@ local nodeMemoryUtil = graphPanel.new(
         sum(node_memory_MemTotal_bytes) by (kubernetes_node)
       )
     |||,
-    legendFormat='{{kubernetes_node}}}'
+    legendFormat='{{kubernetes_node}}'
   ),
 ]);
 
@@ -216,7 +222,7 @@ local nodeCPUUtil = graphPanel.new(
     % of available CPUs currently in use
   |||,
   min=0,
-  max=1
+  max=1,
 ).addTargets([
   prometheus.target(
     |||
@@ -228,7 +234,7 @@ local nodeCPUUtil = graphPanel.new(
         label_replace(kube_node_status_capacity_cpu_cores, "kubernetes_node", "$1", "node", "(.*)")
       ) by (kubernetes_node)
     |||,
-    legendFormat='{{kubernetes_node}}}'
+    legendFormat='{{kubernetes_node}}'
   ),
 ]);
 
@@ -239,18 +245,24 @@ local nonRunningPods = graphPanel.new(
     Pods in states other than 'Running'.
 
     In a functional clusters, pods should not be in non-Running states for long.
-  |||
+  |||,
+  decimals=0,
+  legend_hideZero=true,
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(kube_pod_status_phase{phase!="Running"}) by (phase)',
-    legendFormat='{{phase}}'
+    legendFormat='{{phase}}',
+
   ),
 ]);
 
 
 // NFS Stats
 local userNodesNFSOps = graphPanel.new(
-  'User Nodes NFS Ops'
+  'User Nodes NFS Ops',
+  decimals=0,
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(node_nfs_requests_total[5m])) by (kubernetes_node) > 0',
@@ -259,7 +271,9 @@ local userNodesNFSOps = graphPanel.new(
 ]);
 
 local userNodesIOWait = graphPanel.new(
-  'iowait % on each node'
+  'iowait % on each node',
+  decimals=0,
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(node_nfs_requests_total[5m])) by (kubernetes_node)',
@@ -268,7 +282,9 @@ local userNodesIOWait = graphPanel.new(
 ]);
 
 local userNodesHighNFSOps = graphPanel.new(
-  'NFS Operation Types on user nodes'
+  'NFS Operation Types on user nodes',
+  decimals=0,
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(node_nfs_requests_total[5m])) by (method) > 0',
@@ -277,7 +293,8 @@ local userNodesHighNFSOps = graphPanel.new(
 ]);
 
 local nfsServerCPU = graphPanel.new(
-  'NFS Server CPU'
+  'NFS Server CPU',
+  min=0,
 ).addTargets([
   prometheus.target(
     'avg(rate(node_cpu_seconds_total{job="prometheus-nfsd-server", mode!="idle"}[2m])) by (mode)',
@@ -286,7 +303,9 @@ local nfsServerCPU = graphPanel.new(
 ]);
 
 local nfsServerIOPS = graphPanel.new(
-  'NFS Server Disk ops'
+  'NFS Server Disk ops',
+  decimals=0,
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(node_nfsd_disk_bytes_read_total[5m]))',
@@ -299,7 +318,8 @@ local nfsServerIOPS = graphPanel.new(
 ]);
 
 local nfsServerWriteLatency = graphPanel.new(
-  'NFS Server disk write latency'
+  'NFS Server disk write latency',
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(node_disk_write_time_seconds_total{job="prometheus-nfsd-server"}[5m])) by (device) / sum(rate(node_disk_writes_completed_total{job="prometheus-nfsd-server"}[5m])) by (device)',
@@ -308,7 +328,8 @@ local nfsServerWriteLatency = graphPanel.new(
 ]);
 
 local nfsServerReadLatency = graphPanel.new(
-  'NFS Server disk read latency'
+  'NFS Server disk read latency',
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(node_disk_read_time_seconds_total{job="prometheus-nfsd-server"}[5m])) by (device) / sum(rate(node_disk_reads_completed_total{job="prometheus-nfsd-server"}[5m])) by (device)',
@@ -319,7 +340,8 @@ local nfsServerReadLatency = graphPanel.new(
 // Support Metrics
 local prometheusMemory = graphPanel.new(
   'Prometheus Memory (RSS)',
-  formatY1='bytes'
+  formatY1='bytes',
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(container_memory_rss{pod=~"support-prometheus-server-.*", namespace="support"})'
@@ -327,7 +349,8 @@ local prometheusMemory = graphPanel.new(
 ]);
 
 local prometheusCPU = graphPanel.new(
-  'Prometheus CPU'
+  'Prometheus CPU',
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(container_cpu_usage_seconds_total{pod=~"support-prometheus-server-.*",namespace="support"}[5m]))'
@@ -336,7 +359,8 @@ local prometheusCPU = graphPanel.new(
 
 local prometheusDiskSpace = graphPanel.new(
   'Prometheus Free Disk space',
-  formatY1='bytes'
+  formatY1='bytes',
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(kubelet_volume_stats_available_bytes{namespace="support",persistentvolumeclaim="support-prometheus-server"})'
@@ -345,7 +369,9 @@ local prometheusDiskSpace = graphPanel.new(
 
 local prometheusNetwork = graphPanel.new(
   'Prometheus Network Usage',
-  formatY1='bytes'
+  formatY1='bytes',
+  decimals=0,
+  min=0,
 ).addTargets([
   prometheus.target(
     'sum(rate(container_network_receive_bytes_total{pod=~"support-prometheus-server-.*",namespace="support"}[5m]))',

--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -60,6 +60,9 @@ local clusterMemoryCommitment = graphPanel.new(
     If autoscaling is efficient, this should be a fairly constant, high number (>70%).
   |||,
   min=0,
+  // max=1 may be exceeded in exceptional circumstances like evicted pods
+  // but full is still full. This gets a better view of 'fullness' most of the time.
+  // If the commitment is "off the chart" it doesn't super matter by how much.
   max=1,
 ).addTargets([
   prometheus.target(
@@ -98,6 +101,9 @@ local clusterCPUCommitment = graphPanel.new(
     JupyterHub users mostly are capped by memory, so this is not super useful.
   |||,
   min=0,
+  // max=1 may be exceeded in exceptional circumstances like evicted pods
+  // but full is still full. This gets a better view of 'fullness' most of the time.
+  // If the commitment is "off the chart" it doesn't super matter by how much.
   max=1,
 ).addTargets([
   prometheus.target(
@@ -135,6 +141,9 @@ local nodeCPUCommit = graphPanel.new(
     % of each node guaranteed to pods on it
   |||,
   min=0,
+  // max=1 may be exceeded in exceptional circumstances like evicted pods
+  // but full is still full. This gets a better view of 'fullness' most of the time.
+  // If the commitment is "off the chart" it doesn't super matter by how much.
   max=1,
 ).addTargets([
   prometheus.target(
@@ -165,6 +174,9 @@ local nodeMemoryCommit = graphPanel.new(
     % of each node guaranteed to pods on it
   |||,
   min=0,
+  // max=1 may be exceeded in exceptional circumstances like evicted pods
+  // but full is still full. This gets a better view most of the time.
+  // If the commitment is "off the chart" it doesn't super matter by how much.
   max=1,
 ).addTargets([
   prometheus.target(
@@ -196,6 +208,7 @@ local nodeMemoryUtil = graphPanel.new(
     % of available Memory currently in use
   |||,
   min=0,
+  // since this is actual measured utilization, it should not be able to exceed max=1
   max=1,
 ).addTargets([
   prometheus.target(
@@ -222,6 +235,7 @@ local nodeCPUUtil = graphPanel.new(
     % of available CPUs currently in use
   |||,
   min=0,
+  // since this is actual measured utilization, it should not be able to exceed max=1
   max=1,
 ).addTargets([
   prometheus.target(

--- a/dashboards/usage-stats.jsonnet
+++ b/dashboards/usage-stats.jsonnet
@@ -25,7 +25,8 @@ local templates = [
 local monthlyActiveUsers = graphPanel.new(
   'Active users (over 30 days)',
   bars=true,
-  lines=false
+  lines=false,
+  min=0,
 ).addTargets([
   prometheus.target(
     // Removes any pods caused by stress testing
@@ -51,7 +52,8 @@ local monthlyActiveUsers = graphPanel.new(
 local dailyActiveUsers = graphPanel.new(
   'Active users (over 24 hours)',
   bars=true,
-  lines=false
+  lines=false,
+  min=0,
 ).addTargets([
   prometheus.target(
     // count singleuser-server pods
@@ -77,6 +79,7 @@ local userDistribution = graphPanel.new(
   'User Login Count distribution (over 90d)',
   bars=true,
   lines=false,
+  min=0,
   x_axis_mode='histogram',
 ).addTargets([
   prometheus.target(
@@ -100,7 +103,8 @@ local currentRunningUsers = graphPanel.new(
   'Current running users',
   legend_min=true,
   legend_max=true,
-  legend_current=true
+  legend_current=true,
+  min=0,
 ).addTargets([
   prometheus.target(
     |||


### PR DESCRIPTION
- set min=0 for most panels with absolute values, to avoid misleading zoom-in
- set decimals=0 for integer panels, like node/user counts
- use percentunit for most CPU metrics
- heatmap defaults count duplicates if there's more than one sample per bucket; need interval to match xBucketSize