### PR TITLE
support dashboard: nfs panels to be jupyterhub-home-nfs panels, and misc fixes

### DIFF
--- a/dashboards/common.libsonnet
+++ b/dashboards/common.libsonnet
@@ -144,7 +144,34 @@ local _getDashedLineOverride(pattern, color) = {
       + var.query.withDatasourceFromVariable(self.prometheus)
       + var.query.selectionOptions.withMulti()
       + var.query.selectionOptions.withIncludeAll(value=true, customAllValue='.*')
-      + var.query.queryTypes.withLabelValues('node', 'kube_node_info'),
+      + var.query.queryTypes.withLabelValues('node', 'kube_node_info')
+    ,
+    show_requests:
+      var.custom.new('show_requests', [
+        { key: 'Show', value: '1' },
+        { key: 'Hide', value: '0' },
+      ])
+      + var.custom.generalOptions.withLabel('CPU/Memory requests')
+      + var.custom.generalOptions.withDescription("In panels showing containers' CPU/Memory usage, also show the containers' CPU/Memory requests.")
+      + var.custom.generalOptions.withCurrent('Show', '1')
+    ,
+    show_limits:
+      var.custom.new('show_limits', [
+        { key: 'Show', value: '1' },
+        { key: 'Hide', value: '0' },
+      ])
+      + var.custom.generalOptions.withLabel('CPU/Memory limits')
+      + var.custom.generalOptions.withDescription("In panels showing containers' CPU/Memory usage, also show the containers' CPU/Memory limits.")
+      + var.custom.generalOptions.withCurrent('Hide', '0')
+    ,
+    show_capacity:
+      var.custom.new('show_capacity', [
+        { key: 'Show', value: '1' },
+        { key: 'Hide', value: '0' },
+      ])
+      + var.custom.generalOptions.withLabel('Storage capacity')
+      + var.custom.generalOptions.withDescription("In panels showing storage usage, also show the storage's capacity.")
+      + var.custom.generalOptions.withCurrent('Show', '1'),
   },
 
   _nodePoolLabelKeys: [

--- a/dashboards/support.jsonnet
+++ b/dashboards/support.jsonnet
@@ -59,6 +59,7 @@ local nfsServerCPU =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_requests{pod=~".*home-nfs-.*", container!="", resource="cpu"}) by (namespace, container)
+        and on() vector($show_requests) == 1
       |||
     )
     + prometheus.withLegendFormat('request ({{namespace}}: {{container}})'),
@@ -66,10 +67,10 @@ local nfsServerCPU =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_limits{pod=~".*home-nfs-.*", container!="", resource="cpu"}) by (namespace, container)
+        and on() vector($show_limits) == 1
       |||
     )
-    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})')
-    + prometheus.withHide(),
+    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})'),
   ]);
 
 local nfsServerMemory =
@@ -89,6 +90,7 @@ local nfsServerMemory =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_requests{pod=~".*home-nfs-.*", container!="", resource="memory"}) by (namespace, container)
+        and on() vector($show_requests) == 1
       |||
     )
     + prometheus.withLegendFormat('request ({{namespace}}: {{container}})'),
@@ -96,10 +98,10 @@ local nfsServerMemory =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_limits{pod=~".*home-nfs-.*", container!="", resource="memory"}) by (namespace, container)
+        and on() vector($show_limits) == 1
       |||
     )
-    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})')
-    + prometheus.withHide(),
+    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})'),
   ]);
 
 local nfsServerDiskSpace =
@@ -119,6 +121,7 @@ local nfsServerDiskSpace =
       '$PROMETHEUS_DS',
       |||
         sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".*home-nfs"}) by (namespace, persistentvolumeclaim)
+        and on() vector($show_capacity) == 1
       |||
     )
     + prometheus.withLegendFormat('capacity ({{namespace}}: {{persistentvolumeclaim}})'),
@@ -166,6 +169,7 @@ local promServerCPU =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_requests{pod=~".*prometheus-server-.*", container!="", resource="cpu"}) by (namespace, container)
+        and on() vector($show_requests) == 1
       |||
     )
     + prometheus.withLegendFormat('request ({{namespace}}: {{container}})'),
@@ -173,10 +177,10 @@ local promServerCPU =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_limits{pod=~".*prometheus-server-.*", container!="", resource="cpu"}) by (namespace, container)
+        and on() vector($show_limits) == 1
       |||
     )
-    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})')
-    + prometheus.withHide(),
+    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})'),
   ]);
 
 local promServerMemory =
@@ -196,6 +200,7 @@ local promServerMemory =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_requests{pod=~".*prometheus-server-.*", container!="", resource="memory"}) by (namespace, container)
+        and on() vector($show_requests) == 1
       |||
     )
     + prometheus.withLegendFormat('request ({{namespace}}: {{container}})'),
@@ -203,10 +208,10 @@ local promServerMemory =
       '$PROMETHEUS_DS',
       |||
         sum(kube_pod_container_resource_limits{pod=~".*prometheus-server-.*", container!="", resource="memory"}) by (namespace, container)
+        and on() vector($show_limits) == 1
       |||
     )
-    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})')
-    + prometheus.withHide(),
+    + prometheus.withLegendFormat('limit ({{namespace}}: {{container}})'),
   ]);
 
 local promServerDiskSpace =
@@ -226,6 +231,7 @@ local promServerDiskSpace =
       '$PROMETHEUS_DS',
       |||
         sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".*-prometheus-server"}) by (namespace, persistentvolumeclaim)
+        and on() vector($show_capacity) == 1
       |||
     )
     + prometheus.withLegendFormat('capacity ({{namespace}}: {{persistentvolumeclaim}})'),
@@ -261,6 +267,9 @@ dashboard.new('NFS usage, NFS server, and Prometheus server diagnostics')
 + dashboard.withEditable(true)
 + dashboard.withVariables([
   common.variables.prometheus,
+  common.variables.show_requests,
+  common.variables.show_limits,
+  common.variables.show_capacity,
 ])
 + dashboard.withPanels(
   grafonnet.util.grid.makeGrid(


### PR DESCRIPTION
After this change, which touches a lot in the support dashboard, we get the following assuming jupyterhub-home-nfs is running.

- fixes #157 
- fixes #158

## How it looks with this PR

We have three new variables with show/hide values to toggle showing CPU/Memory Requests/Limits, as well as show/hide storage capacity. We default to showing requests and capacity, but not limits. Requests and capacity are often relevant perspective that can drive action, while relating to limits often aren't.

<img width="1109" height="86" alt="image" src="https://github.com/user-attachments/assets/ee89dbac-736d-4f61-89f3-0326a70e52be" />

<img width="3060" height="835" alt="image" src="https://github.com/user-attachments/assets/04995172-b00d-4b1c-aec1-c7319b957b0c" />
<img width="3060" height="1583" alt="image" src="https://github.com/user-attachments/assets/9aee4e3d-8f1e-4ab3-8ac6-7afa61d5e304" />
<img width="3060" height="1583" alt="image" src="https://github.com/user-attachments/assets/f5aaa0e6-b3d1-4938-9644-aaf409f0385c" />

## How it looked before this PR

<img width="3060" height="1583" alt="image" src="https://github.com/user-attachments/assets/91e6b21d-5e2e-445f-b4d5-abca6ae73d1f" />
<img width="3060" height="1537" alt="image" src="https://github.com/user-attachments/assets/1a463a70-a930-41a5-99a9-6d53358da23c" />
<img width="3060" height="1537" alt="image" src="https://github.com/user-attachments/assets/d258a94f-2184-4966-a051-5be4d06495b0" />


## Misc notes

- If CPU/Memory requests are configured for containers, there will be dashed red lines representing them. In the screenshots below, I have requests for prometheus-server, but not for jupyterhub-home-nfs's nfs-server pods' containers.
- If CPU/Memory limits are configured, you can open a panel and toggle the visibility on a query related to limits. They are hidden by default as they likely makes things hard to read, since the limits can be far higher than requests and typical usage.
- For PVC's there are dashed red lines representing their capacity.