### PR TITLE
jupyterhub dashboard: transition two panels to heatmaps, and tweak existing heatmaps

### DIFF
--- a/dashboards/common.libsonnet
+++ b/dashboards/common.libsonnet
@@ -73,10 +73,10 @@ local _getDashedLineOverride(pattern, color) = {
   // grafonnet ref: https://grafana.github.io/grafonnet/API/panel/heatmap/index.html
   heatmapOptions:
     heatmap.options.withCalculate(true)
-    + heatmap.queryOptions.withMaxDataPoints('48')
+    + heatmap.queryOptions.withMaxDataPoints('60')  // need to match xBuckets
     + heatmap.options.color.withScheme('Greens')
     + heatmap.options.calculation.xBuckets.withMode('count')
-    + heatmap.options.calculation.xBuckets.withValue('48')
+    + heatmap.options.calculation.xBuckets.withValue('60')  // need to match withMaxDataPoints
     + heatmap.options.calculation.yBuckets.withMode('count')
     + heatmap.options.calculation.yBuckets.withValue('12')
   ,


### PR DESCRIPTION
The hub response times and server startup times panels are made into heatmaps.

Before | After
-|-
<img width="1829" height="1565" alt="image" src="https://github.com/user-attachments/assets/b61af371-b4b5-4c4f-8553-ab98b1c35b3e" />|<img width="1829" height="1565" alt="image" src="https://github.com/user-attachments/assets/eca1c1a2-7469-4d8a-9c89-3c9094d4cc2c" />

The three existing heatmaps were tweaked a bit:

Before | After
-|-
<img width="3653" height="1565" alt="image" src="https://github.com/user-attachments/assets/793c995d-3fb7-4982-8651-cb0650b49d2d" />|<img width="3669" height="1565" alt="image" src="https://github.com/user-attachments/assets/a315da2e-3e80-4808-bdd9-ff7d971b249d" />

- Closes #133