### PR TITLE
Change CPU panels' units from percent to sishort (20% -> 200m)

### DIFF
--- a/dashboards/group.jsonnet
+++ b/dashboards/group.jsonnet
@@ -61,6 +61,8 @@ local cpuUsage =
     |||
       Per group CPU usage
 
+      The measured unit are CPU cores, and they are written out with SI prefixes, so 100m means 0.1 CPU cores.
+
       User groups are derived from authenticator managed groups where available, e.g. GitHub teams. If a user is a member of multiple groups, then they will be assigned to the group 'other' by default. 
 
       Requires https://github.com/2i2c-org/jupyterhub-groups-exporter to
@@ -204,6 +206,8 @@ local cpuRequests =
   + ts.panelOptions.withDescription(
     |||
       Per group CPU requests
+
+      The measured unit are CPU cores, and they are written out with SI prefixes, so 100m means 0.1 CPU cores.
 
       User groups are derived from authenticator managed groups where available, e.g. GitHub teams. If a user is a member of multiple groups, then they will be assigned to the group 'other' by default. 
 

--- a/dashboards/jupyterhub.libsonnet
+++ b/dashboards/jupyterhub.libsonnet
@@ -159,5 +159,10 @@ local prometheus = grafonnet.query.prometheus;
         irate(container_cpu_usage_seconds_total{name!=""}[5m])
       |||,
     )
+    + ts.panelOptions.withDescription(
+      |||
+        The measured unit are CPU cores, and they are written out with SI prefixes, so 100m means 0.1 CPU cores.
+      |||
+    )
     + ts.standardOptions.withUnit('sishort'),
 }

--- a/dashboards/support.jsonnet
+++ b/dashboards/support.jsonnet
@@ -46,6 +46,11 @@ local nfsServerCPU =
   common.tsOptions
   + common.tsRequestLimitStylingOverrides
   + ts.new('NFS server CPU usage')
+  + ts.panelOptions.withDescription(
+    |||
+      The measured unit are CPU cores, and they are written out with SI prefixes, so 100m means 0.1 CPU cores.
+    |||
+  )
   + ts.standardOptions.withUnit('sishort')
   + ts.queryOptions.withTargets([
     prometheus.new(
@@ -156,6 +161,11 @@ local promServerCPU =
   common.tsOptions
   + common.tsRequestLimitStylingOverrides
   + ts.new('Prometheus server CPU usage')
+  + ts.panelOptions.withDescription(
+    |||
+      The measured unit are CPU cores, and they are written out with SI prefixes, so 100m means 0.1 CPU cores.
+    |||
+  )
   + ts.standardOptions.withUnit('sishort')
   + ts.queryOptions.withTargets([
     prometheus.new(

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -38,6 +38,8 @@ local cpuUsage =
   + ts.panelOptions.withDescription(
     |||
       Per user CPU usage
+
+      The measured unit are CPU cores, and they are written out with SI prefixes, so 100m means 0.1 CPU cores.
     |||
   )
   + ts.standardOptions.withUnit('sishort')
@@ -127,6 +129,8 @@ local cpuRequests =
   + ts.panelOptions.withDescription(
     |||
       Per user CPU requests
+
+      The measured unit are CPU cores, and they are written out with SI prefixes, so 100m means 0.1 CPU cores.
     |||
   )
   + ts.standardOptions.withUnit('sishort')


### PR DESCRIPTION
Before | After
-|-
<img width="1824" height="768" alt="image" src="https://github.com/user-attachments/assets/8a99709c-25fb-4917-82cf-4e26ddf0157c" />|<img width="1824" height="768" alt="image" src="https://github.com/user-attachments/assets/c9ce86d2-0b07-4a4e-9d13-2e2b863e8ce9" />
<img width="1447" height="849" alt="image" src="https://github.com/user-attachments/assets/ffba6bcd-76e7-4706-9dcc-52caf92f9cec" />|<img width="1447" height="849" alt="image" src="https://github.com/user-attachments/assets/79be5277-ca92-4ebd-b97c-951dc6cb2d3e" />
<img width="1447" height="849" alt="image" src="https://github.com/user-attachments/assets/81fac93f-7a7e-41d1-8cbc-4d5cf8854bd0" />|<img width="1447" height="849" alt="image" src="https://github.com/user-attachments/assets/21018a1d-959b-4306-b2ab-00d20a2abd53" />

The groups panel "CPU Usage" isn't screenshotted, because I haven't got it to work yet due to #165.

Unchanged panels with CPU related data include:
<img width="823" height="1643" alt="image" src="https://github.com/user-attachments/assets/1d4920ad-a49a-473a-ab1e-34a42698f7e0" />
