### PR TITLE
Username mapping for both of kubespawner's escaping schemes

### DIFF
--- a/dashboards/group.jsonnet
+++ b/dashboards/group.jsonnet
@@ -129,19 +129,22 @@ local homedirSharedUsage =
           # make namespace/directory combinations become more namespace/directory/usergroup combinations
           * on (namespace, directory) group_right()
           group(
-            # FIXME: We assume ability to match the escaped username with the
-            #        directory name, but how usernames are escaped has changed
-            #        over time - the directory name may or may not match
-            #        `username_escaped`.
-            #
-            #        - actual:      my.name@example.com
-            #        - old escaped: my-2ename-40example-2ecom
-            #        - new escaped: my-name-example-com---abcd1234
-            #
-            # duplicate jupyterhub_user_group_info's username_escaped label as directory
-            label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username_escaped=~".*", usergroup=~"$user_group"},
-              "directory", "$1", "username_escaped", "(.+)"
+            # match using username_safe (kubespawner's modern "safe" scheme)
+            (
+              # duplicate jupyterhub_user_group_info's username_safe label as directory
+              label_replace(
+                jupyterhub_user_group_info{namespace=~"$hub_name", username_safe=~".*", usergroup=~"$user_group"},
+                "directory", "$1", "username_safe", "(.+)"
+              )
+            )
+            or
+            # match using username_escaped (kubespawner's legacy "escape" scheme)
+            (
+              # duplicate jupyterhub_user_group_info's username_escaped label as directory
+              label_replace(
+                jupyterhub_user_group_info{namespace=~"$hub_name", username_escaped=~".*", usergroup=~"$user_group"},
+                "directory", "$1", "username_escaped", "(.+)"
+              )
             )
           ) by (namespace, directory, usergroup)
 

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -83,14 +83,35 @@ local homedirSharedUsage =
     prometheus.new(
       '$PROMETHEUS_DS',
       |||
-        max(
-          dirsize_total_size_bytes{namespace=~"$hub_name"}
-          * on (namespace, directory) group_left(username)
+        sum(
+
+          # max is used to de-duplicate data from multiple sources
+          max(
+            dirsize_total_size_bytes{namespace=~"$hub_name"}
+          ) by (namespace, directory)
+
+          # make namespace/directory combinations become more namespace/directory/username combinations
+          * on (namespace, directory) group_right()
           group(
-            label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username_escaped=~".*"},
-                "directory", "$1", "username_escaped", "(.+)")
-          ) by (directory, namespace, username)
+            # match using username_safe (kubespawner's modern "safe" scheme)
+            (
+              # duplicate jupyterhub_user_group_info's username_safe label as directory
+              label_replace(
+                jupyterhub_user_group_info{namespace=~"$hub_name", username_safe=~".*"},
+                "directory", "$1", "username_safe", "(.+)"
+              )
+            )
+            or
+            # match using username_escaped (kubespawner's legacy "escape" scheme)
+            (
+              # duplicate jupyterhub_user_group_info's username_escaped label as directory
+              label_replace(
+                jupyterhub_user_group_info{namespace=~"$hub_name", username_escaped=~".*"},
+                "directory", "$1", "username_escaped", "(.+)"
+              )
+            )
+          ) by (namespace, directory, username)
+
         ) by (namespace, username)
       |||
     )


### PR DESCRIPTION
This PR depends on https://github.com/2i2c-org/jupyterhub-groups-exporter/pull/41 and has also been tested together with it.

---

In panels related to storage, we try to map directory names to the usernames that they were created for.

We want to support mapping `my.name@example.com` as a username to either `my-2ename-40example-2ecom` or `my-name-example-com---abcd1234`, and previously we only mapped `my-2ename-40example-2ecom`, but with this
change we could map also `my-name-example-com---abcd1234` to the username.

```
actual username:          my.name@example.com
legacy scheme ("escape"): my-2ename-40example-2ecom
modern scheme ("safe"):   my-name-example-com---abcd1234
```

This requires version >= 1.2.0 of jupyterhub-groups-exporter, where the `username_safe` label is available, but it won't error without it.