### PR TITLE
groups dashboard: filter out the pseudo group 'multiple'

### DIFF
--- a/dashboards/common.libsonnet
+++ b/dashboards/common.libsonnet
@@ -185,6 +185,13 @@ local _getDashedLineOverride(pattern, color) = {
       + var.query.withDatasourceFromVariable(self.prometheus)
       + var.query.selectionOptions.withMulti()
       + var.query.selectionOptions.withIncludeAll(value=true, customAllValue='.*')
+      // If jupyterhub-groups-exporter is configured with `double_count=True` as
+      // it is by default, a pseudo group named `multiple` will also be reported
+      // by jupyterhub-groups-exporter next to real groups and the `none` group.
+      // A user part of multiple real groups, will also be part of the `multiple`
+      // pseudo-group. Presenting this groups is assumed to not improve the user
+      // experience, so we exclude it.
+      + var.query.withRegex('^(?!multiple$).+')
       + var.query.queryTypes.withLabelValues('usergroup', 'jupyterhub_user_group_info')
     ,
     user_name:

--- a/dashboards/group.jsonnet
+++ b/dashboards/group.jsonnet
@@ -42,7 +42,7 @@ local memoryUsage =
           group(
             # duplicate jupyterhub_user_group_info's username label as annotation_hub_jupyter_org_username
             label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group"},
+              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group", usergroup!="multiple"},
               "annotation_hub_jupyter_org_username", "$1", "username", "(.+)"
             )
           ) by (namespace, annotation_hub_jupyter_org_username, usergroup)
@@ -92,7 +92,7 @@ local cpuUsage =
           group(
             # duplicate jupyterhub_user_group_info's username label as annotation_hub_jupyter_org_username
             label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group"},
+              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group", usergroup!="multiple"},
               "annotation_hub_jupyter_org_username", "$1", "username", "(.+)"
             )
           ) by (namespace, annotation_hub_jupyter_org_username, usergroup)
@@ -134,14 +134,14 @@ local homedirSharedUsage =
             # match using username_safe (kubespawner's modern "safe" scheme)
             # duplicate jupyterhub_user_group_info's username_safe label as directory
             label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username_safe=~".*", usergroup=~"$user_group"},
+              jupyterhub_user_group_info{namespace=~"$hub_name", username_safe=~".*", usergroup=~"$user_group", usergroup!="multiple"},
               "directory", "$1", "username_safe", "(.+)"
             )
             or
             # match using username_escaped (kubespawner's legacy "escape" scheme)
             # duplicate jupyterhub_user_group_info's username_escaped label as directory
             label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username_escaped=~".*", usergroup=~"$user_group"},
+              jupyterhub_user_group_info{namespace=~"$hub_name", username_escaped=~".*", usergroup=~"$user_group", usergroup!="multiple"},
               "directory", "$1", "username_escaped", "(.+)"
             )
           ) by (namespace, directory, usergroup)
@@ -188,7 +188,7 @@ local memoryRequests =
           group(
             # duplicate jupyterhub_user_group_info's username label as annotation_hub_jupyter_org_username
             label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group"},
+              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group", usergroup!="multiple"},
               "annotation_hub_jupyter_org_username", "$1", "username", "(.+)"
             )
           ) by (namespace, annotation_hub_jupyter_org_username, usergroup)
@@ -237,7 +237,7 @@ local cpuRequests =
           group(
             # duplicate jupyterhub_user_group_info's username label as annotation_hub_jupyter_org_username
             label_replace(
-              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group"},
+              jupyterhub_user_group_info{namespace=~"$hub_name", username=~".*", usergroup=~"$user_group", usergroup!="multiple"},
               "annotation_hub_jupyter_org_username", "$1", "username", "(.+)"
             )
           ) by (namespace, annotation_hub_jupyter_org_username, usergroup)


### PR DESCRIPTION
This PR filters out the pseudo user group `multiple` from the query results, and also hides it in the variable to select specific user groups.

I perceive the inclusion of it to reduce the UX. Before seeing it, I felt certain that any user part of any real group would be counted towards that real group, no matter if the user was part of multiple groups. However, seeing the `multiple` group, I became uncertain.